### PR TITLE
Fix RangeErrors when trying to pack large final files.

### DIFF
--- a/pdftex-worker.js
+++ b/pdftex-worker.js
@@ -78,10 +78,14 @@ self['onmessage'] = function(ev) {
         fn = cmd.substr(3);
         res = FS[fn].apply(FS, args);
         if(cmd === 'FS_readFile') {
-          var temp = "";
-          for(var i=0, l=res.length; i<l; i++)
-            temp += String.fromCharCode(res[i]);
-          res = temp;
+          var res2 = "";
+          var chunk = 8*1024;
+          var i;
+          for (i = 0; i < res.length/chunk; i++) {
+            res2 += String.fromCharCode.apply(null, res.subarray(i*chunk, (i+1)*chunk));
+          }
+          res2 += String.fromCharCode.apply(null, res.subarray(i*chunk));
+          res = res2;
         } else
           res = true;
       }

--- a/pdftex-worker.js
+++ b/pdftex-worker.js
@@ -77,12 +77,16 @@ self['onmessage'] = function(ev) {
       try {
         fn = cmd.substr(3);
         res = FS[fn].apply(FS, args);
-        if(cmd === 'FS_readFile')
-          res = String.fromCharCode.apply(null, res);
-        else
+        if(cmd === 'FS_readFile') {
+          var temp = "";
+          for(var i=0, l=res.length; i<l; i++)
+            temp += String.fromCharCode(res[i]);
+          res = temp;
+        } else
           res = true;
       }
       catch(e) {
+        console.log(e);
         res = false;
       }
     break;


### PR DESCRIPTION
This is a potential fix to https://github.com/manuels/texlive.js/issues/18. The default demo wasn't working for me without this change, it was just silently getting to the end of compiling and then seemingly sat there.