### PR TITLE
Make worker path configurable

### DIFF
--- a/pdftex.js
+++ b/pdftex.js
@@ -1,5 +1,8 @@
-var PDFTeX = function() {
-  var worker = new Worker("pdftex-worker.js");
+var PDFTeX = function(opt_workerPath) {
+  if (!opt_workerPath) {
+    opt_workerPath = 'pdftex-worker.js';
+  }
+  var worker = new Worker(opt_workerPath);
   var self = this;
   var initialized = false;
 


### PR DESCRIPTION
This is a proposed fix for #27. It's not as elegant as trying to detect where pdftex.js is being served, but it's simple and doesn't assume a web context. If the path is left out, root is assumed.